### PR TITLE
Add `go get` before `go install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ API](http://developer.github.com/v3/search/)
 ## Installation
 
 ```
+go get github.com/Keithbsmiley/ghs
 go install github.com/Keithbsmiley/ghs
 ```
 


### PR DESCRIPTION
The installation fails if one doesn't have the package locally
